### PR TITLE
Kill iso on dispose

### DIFF
--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -302,6 +302,7 @@ abstract class BaseNode {
     _soldierDiscovered.close();
     _socket.close();
     _logs.close();
+    iso.kill();
   }
 
   void info() {


### PR DESCRIPTION
This means the Node and Commander can be recreated within one lifecycle of the application.
This acts as a very neat solution to issue #2 that I created yesterday.